### PR TITLE
Clean test redundancies

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -288,8 +288,6 @@ TEST_GROUPS = {
     ],
 
     "articles_and_plural": [
-        ("zambah", "Zombie"),
-        ("harman", "Human"),
         ("zambahz barg bra!nz", "Zombies eat brains"),
         ("zambah barg bra!n", "Zombie eats a brain"),
     ],
@@ -392,16 +390,6 @@ TEST_GROUPS = {
     ("bra!nz", "Brains"),
    ],
 
-   "plural_and_lookup": [
-    ("zambahz", "Zombies"),
-    ("harmanz", "Humans"),
-   ],
-
-   "pos_disambiguation": [
-    ("barg", "Eat"),
-    # later: ambiguous words
-   ],
-
    "stress_tests":  [
     ("zambah maz maz barg bra!nz", "Zombie must eat brains"),
     ("nah maz barg bra!nz", "Do not must eat brains"),
@@ -448,9 +436,6 @@ TEST_GROUPS = {
        # Determiner repetition
        ("mah mah bra!nz", "My brains"),
 
-       # regression test determiner repetition fixes
-       ("mah zambah barg bra!nz", "I eat brains"),
-       ("g!b mah bra!nz", "Give me brains"),
    ],
 
    "decision_tests": [


### PR DESCRIPTION
Several test redundancies were found in looking over the test suite.  They are thoroughly discussed in the commit messages of the two commits here (one for structure tests, one for translation tests).
